### PR TITLE
Clean up dependencies

### DIFF
--- a/lib/sidecloq.rb
+++ b/lib/sidecloq.rb
@@ -1,7 +1,7 @@
 require 'sidekiq'
 require 'concurrent'
+require 'json'
 require 'redlock'
-require 'multi_json'
 require 'rufus-scheduler'
 
 require 'sidecloq/utils'

--- a/lib/sidecloq/schedule.rb
+++ b/lib/sidecloq/schedule.rb
@@ -23,7 +23,7 @@ module Sidecloq
 
         redis { |r| r.hgetall(REDIS_KEY) }.tap do |h|
           h.each do |name, config|
-            specs[name] = MultiJson.decode(config)
+            specs[name] = JSON.parse(config)
           end
         end
       end
@@ -68,7 +68,7 @@ module Sidecloq
     def save_all_to_redis
       redis do |r|
         @job_specs.each do |name, spec|
-          r.hset(REDIS_KEY, name, MultiJson.encode(spec))
+          r.hset(REDIS_KEY, name, spec.to_json)
         end
       end
     end

--- a/sidecloq.gemspec
+++ b/sidecloq.gemspec
@@ -23,11 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'redlock', '~> 0.1.2'
   # mimics some dev dependencies of sidekiq:
   spec.add_dependency 'concurrent-ruby'
-  spec.add_dependency 'sinatra', '~> 1.4', '>= 1.4.6'
-  spec.add_dependency 'redis-namespace', '~> 1.5', '>= 1.5.2'
-  spec.add_dependency 'multi_json', '~> 1.11'
   spec.add_dependency 'rufus-scheduler', '~> 3.1', '>= 3.1.10'
 
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'redis-namespace', '~> 1.5', '>= 1.5.2'
 end


### PR DESCRIPTION
- Drop sinatra (not required and removed in Sidekiq 4.2)
- Replace multi_json with standard json library
- Move redis-namespace to development dependencies