### PR TITLE
Mention `args` support for schedule definition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,16 @@ the above configuration block).
 ```yaml
 my_scheduled_job: # a unique name for this schedule
   class: Jobs::DoWork # the job class
+  args: [100]       # (optional) set of arguments
   cron: "* * * * *" # cron formatted schedule
   queue: "queue_name" # Sidekiq queue for job
+
+my_scheduled_job_with_args:
+  class: Jobs::WorkerWithArgs
+  args:
+    batch_size: 100
+  cron: "1 1 * * *"
+  queue: "queue_name"
 
 my_other_scheduled_job:
   class: Jobs::AnotherClassName

--- a/test/fixtures/sidecloq.yml
+++ b/test/fixtures/sidecloq.yml
@@ -7,3 +7,10 @@ my_other_scheduled_job:
   class: Jobs::AnotherClassName
   cron: "1 1 * * *"
   queue: "a_different_queue"
+
+my_scheduled_job_with_args:
+  class: Jobs::WorkerWithArgs
+  args:
+    batch_size: 100
+  cron: "1 1 * * *"
+  queue: "queue_name"

--- a/test/test_schedule.rb
+++ b/test/test_schedule.rb
@@ -7,7 +7,8 @@ class TestSchedule < Sidecloq::Test
         'test_job' => {
           'class' => 'JobClass',
           'cron' => '0 7 * * *',
-          'queue' => 'default'
+          'queue' => 'default',
+          'args' => { 'batch' => 100 }
         }
       }
     end
@@ -25,6 +26,7 @@ class TestSchedule < Sidecloq::Test
 
       assert_equal('test_job', loaded.job_specs.keys.first)
       assert_equal('0 7 * * *', loaded.job_specs.values.first['cron'])
+      assert_equal({'batch' => 100}, loaded.job_specs.values.first['args'])
 
       file.delete
     end

--- a/test/test_sidecloq.rb
+++ b/test/test_sidecloq.rb
@@ -56,13 +56,13 @@ class TestSidecloq < Sidecloq::Test
 
       it 'loads a given filename' do
         Sidecloq.options[:schedule_file] = File.expand_path('../fixtures/sidecloq.yml', __FILE__)
-        assert_equal 2, Sidecloq.extract_schedule.job_specs.keys.length
+        assert_equal 3, Sidecloq.extract_schedule.job_specs.keys.length
       end
 
       it 'finds a config file relative to rails root' do
         define_rails!
         Sidecloq.options[:schedule_file] = '/fixtures/sidecloq.yml'
-        assert_equal 2, Sidecloq.extract_schedule.job_specs.keys.length
+        assert_equal 3, Sidecloq.extract_schedule.job_specs.keys.length
       end
 
       it 'defaults to an empty schedule' do


### PR DESCRIPTION
If I had not read through the RSpec `test_job_enqueuer.rb`, I would have missed that sidecloq supports passing in both Hash and Array defined arguments. This patch surfaces that feature in the README and adds a test to the YAML parser to make sure its extracted.

## Changes

* Added a spec to verify it is read from YAML
* Change examples in README so folks know it exists