### PR TITLE
Dup the job spec when enqueueing a job

### DIFF
--- a/lib/sidecloq/job_enqueuer.rb
+++ b/lib/sidecloq/job_enqueuer.rb
@@ -3,7 +3,8 @@ module Sidecloq
     attr_reader :spec, :klass
 
     def initialize(spec)
-      @spec = spec
+      # Dup to prevent JID reuse in subsequent enqueue's
+      @spec = spec.dup
       @klass = spec['class'].constantize
     end
 

--- a/test/test_job_enqueuer.rb
+++ b/test/test_job_enqueuer.rb
@@ -18,6 +18,12 @@ class TestJobEnqueuer < Sidecloq::Test
         job = Sidekiq::Queue.new.first
         assert_equal 'DummyJob', job.klass
       end
+
+      it 'keeps the origininal spec' do
+        original_spec = spec.dup
+        enqueuer.enqueue
+        assert_equal original_spec, spec
+      end
     end
 
     describe 'active_job' do

--- a/test/test_scheduler.rb
+++ b/test/test_scheduler.rb
@@ -44,5 +44,13 @@ class TestScheduler < Sidecloq::Test
       scheduler.safe_enqueue_job('bad', {})
       assert_equal 0, Sidekiq::Stats.new.enqueued
     end
+
+    it 'has a unqiue JID for each enqueue call' do
+      jid_1 = scheduler.safe_enqueue_job('test', specs[:test])
+      jid_2 = scheduler.safe_enqueue_job('test', specs[:test])
+      refute_nil jid_1
+      refute_nil jid_2
+      refute_equal jid_1, jid_2
+    end
   end
 end


### PR DESCRIPTION
Sidekiq::Client adds the JID it generates to the spec, since the spec is
kept in memory by the scheduler, the next time the job is enqueued the
spec includes this JID and Sidekiq will use that instead of generating a
new one.

This can result in multiple jobs with the same id either enqueued or
active. This breaks the locking mechanism of sidekiq-unique-jobs and
might have some other unwanted effects.