### PR TITLE
Constantize job class in spec

### DIFF
--- a/lib/sidecloq/job_enqueuer.rb
+++ b/lib/sidecloq/job_enqueuer.rb
@@ -1,11 +1,11 @@
 module Sidecloq
   class JobEnqueuer
-    attr_reader :spec, :klass
+    attr_reader :spec
 
     def initialize(spec)
       # Dup to prevent JID reuse in subsequent enqueue's
       @spec = spec.dup
-      @klass = spec['class'].constantize
+      @spec['class'] = spec['class'].constantize
     end
 
     def enqueue
@@ -17,6 +17,10 @@ module Sidecloq
     end
 
     private unless $TESTING
+
+    def klass
+      spec['class']
+    end
 
     def active_job_class?
       defined?(ActiveJob::Base) && klass < ActiveJob::Base

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -49,6 +49,7 @@ class DummyScheduler
 end
 
 class DummyJob
+  include Sidekiq::Worker
 end
 
 require 'active_job'

--- a/test/test_job_enqueuer.rb
+++ b/test/test_job_enqueuer.rb
@@ -19,6 +19,13 @@ class TestJobEnqueuer < Sidecloq::Test
         assert_equal 'DummyJob', job.klass
       end
 
+      it 'applies the job class sidekiq options' do
+        DummyJob.sidekiq_options retry: false
+        enqueuer.enqueue
+        job = Sidekiq::Queue.new.first
+        assert_equal false, job.item['retry']
+      end
+
       it 'keeps the origininal spec' do
         original_spec = spec.dup
         enqueuer.enqueue


### PR DESCRIPTION
Sidekiq::Client.push requires a class to correctly set the configured
sidekiq options for the job.

Sidekiq fell back to the default job options, thus ignoring a.o retry: false on some jobs.