### PR TITLE
Deadlock when stopping with multiple runners

### DIFF
--- a/lib/sidecloq/runner.rb
+++ b/lib/sidecloq/runner.rb
@@ -28,8 +28,8 @@ module Sidecloq
       if @locker.locked?
         @scheduler.stop(timeout)
         @locker.stop(timeout)
+        @thread.join if @thread
       end
-      @thread.join if @thread
       logger.debug('Stopped runner')
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -28,12 +28,18 @@ module Sidecloq
 end
 
 class DummyLocker
+  def initialize(locked = true)
+    @obtained_lock = Concurrent::Event.new
+    @obtained_lock.set if locked
+  end
+
   def with_lock
+    @obtained_lock.wait
     yield
   end
 
   def locked?
-    true
+    @obtained_lock.set?
   end
 
   def stop(timeout = nil)

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -24,5 +24,27 @@ class TestRunner < Sidecloq::Test
 
       r.stop
     end
+
+    it 'stops when not leader (non-blocking)' do
+      leader = Sidecloq::Runner.new(
+        locker: DummyLocker.new(true),
+        scheduler: DummyScheduler.new
+      )
+      leader.run
+      assert true
+
+      runner = Sidecloq::Runner.new(
+        locker: DummyLocker.new(false),
+        scheduler: DummyScheduler.new
+      )
+      runner.run
+      assert true
+
+      runner.stop
+      assert true
+
+      leader.stop
+      assert true
+    end
   end
 end


### PR DESCRIPTION
We're using Sideckiq/Sidecloq on multiple servers and we discovered that the Sidekiq servers that were not leaders in Sidecloq would always fail to restart (stop) properly, systemd always have to send a SIGKILL after the initial SIGTERM.

Turns out I think there is a deadlock because of this line : https://github.com/mattyr/sidecloq/blob/e25c366dac3dc2bb097983ac63507ad62f2bb4ab/lib/sidecloq/runner.rb#L32 when using multiple runners at the same time.

The thread will wait forever for the lock (see : https://github.com/mattyr/sidecloq/blob/e25c366dac3dc2bb097983ac63507ad62f2bb4ab/lib/sidecloq/locker.rb#L22) but it might never get it.

So when a runner is not `locked?` (a.k.a. not leader) I think it shouldn't join on the thread and simply exit. I don't think it needs to wait for anything since it is not the leader anyways.

I also created a test showing off the deadlock, I had to make some changes to DummyLocker so it works more like the real version.