### PR TITLE
Fix issue where the Rack session is invalid for rake web

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,8 +41,13 @@ task :web do
 
   require 'sidekiq/web'
   require 'sidecloq/web'
+  require 'securerandom'
 
   Rack::Server.start(
-    app: Sidekiq::Web
+    app:
+      Rack::Builder.app do
+        use Rack::Session::Cookie, secret: SecureRandom.hex(32), same_site: true, max_age: 86400
+        run Sidekiq::Web
+      end
   )
 end


### PR DESCRIPTION
Without this, you will get an Internal Server Error stating:

    Sidekiq::Web needs a valid Rack session for CSRF protection. If this is a Rails app,
    make sure you mount Sidekiq::Web *inside* your application routes:

    Rails.application.routes.draw do
      mount Sidekiq::Web => "/sidekiq"
      ....
    end

    If this is a Rails app in API mode, you need to enable sessions.

      https://guides.rubyonrails.org/api_app.html#using-session-middlewares

    If this is a bare Rack app, use a session middleware before Sidekiq::Web:

      # first, use IRB to create a shared secret key for sessions and commit it
      require 'securerandom'; File.open(".session.key", "w") {|f| f.write(SecureRandom.hex(32)) }

      # now use the secret with a session cookie middleware
      use Rack::Session::Cookie, secret: File.read(".session.key"), same_site: true, max_age: 86400
      run Sidekiq::Web