### PR TITLE
wip #43 add next time at to web UI

### DIFF
--- a/lib/sidecloq/web.rb
+++ b/lib/sidecloq/web.rb
@@ -6,7 +6,7 @@ module Sidecloq
     def self.registered(app)
       app.get '/recurring' do
         @schedule = Schedule.from_redis
-
+        @helpers = Sidecloq::Web::Helpers
         erb File.read(File.join(VIEW_PATH, 'recurring.erb'))
       end
 
@@ -21,7 +21,26 @@ module Sidecloq
         redirect "#{root_path}recurring"
       end
     end
+
+    ##
+    # Helpers for the the web view
+    class Helpers
+      def self.next_run(cronline)
+        Fugit.parse_cron(cronline).next_time.send(:to_time) rescue nil
+      end
+      def self.time_in_words(t)
+        return unless t.is_a?(Time)
+        t.strftime("%D %R")
+      end
+      def self.time_in_words_to_now(t)
+        return unless t.is_a?(Time)
+        hrs = (t - Time.now) / 1.hour
+        min = hrs.modulo(1) * 60
+        "#{hrs.truncate} hrs #{min.ceil} min"
+      end
+    end
   end
+
 end
 
 Sidekiq::Web.register(Sidecloq::Web)

--- a/lib/sidecloq/web.rb
+++ b/lib/sidecloq/web.rb
@@ -25,8 +25,14 @@ module Sidecloq
     ##
     # Helpers for the the web view
     class Helpers
-      def self.next_run(cronline)
-        Fugit.parse_cron(cronline).next_time.send(:to_time) rescue nil
+      def self.next_run_at(cronline)
+        t = Fugit.parse_cron(cronline).next_time.send(:to_time) rescue nil
+        if t
+          [
+            time_in_words(t),
+            time_in_words_to_now(t)
+          ].join(" ")
+        end
       end
       def self.time_in_words(t)
         return unless t.is_a?(Time)

--- a/web/views/recurring.erb
+++ b/web/views/recurring.erb
@@ -20,12 +20,7 @@
           <td><%= name %></td>
           <td><%= job_spec.fetch 'cron', job_spec['every'] %></td>
           <td>
-            <% t = @helpers.next_run(job_spec.fetch 'cron') %>
-            <% if t %>
-              <%= @helpers.time_in_words_to_now(t.send(:to_time)) %>
-              @
-              <%= @helpers.time_in_words(t) %>
-            <% end %>
+            <%= @helpers.next_run_at(job_spec.fetch('cron')) %>
           </td>
           <td><%= job_spec['class'] %></td>
           <td>

--- a/web/views/recurring.erb
+++ b/web/views/recurring.erb
@@ -6,6 +6,7 @@
       <tr>
         <th>Name</th>
         <th>Cron</th>
+        <th>Next Run</th>
         <th>Class</th>
         <th>Queue</th>
         <th>Arguments</th>
@@ -18,6 +19,14 @@
         <tr>
           <td><%= name %></td>
           <td><%= job_spec.fetch 'cron', job_spec['every'] %></td>
+          <td>
+            <% t = @helpers.next_run(job_spec.fetch 'cron') %>
+            <% if t %>
+              <%= @helpers.time_in_words_to_now(t.send(:to_time)) %>
+              @
+              <%= @helpers.time_in_words(t) %>
+            <% end %>
+          </td>
           <td><%= job_spec['class'] %></td>
           <td>
             <a href="<%= root_path %>queues/<%= job_spec.fetch('queue', 'default') %>"><%= job_spec.fetch('queue', 'default') %></a>


### PR DESCRIPTION
This PR addresses issue #43, adding some human readable information "Next Run" information to the Web UI. 

Method:
1. Parse the cron string using Fugit.parse_cron (no additional dependency required)
2. Display the **Next Run** column in the web UI, e.g. 10 hrs 20 min @ 10/06/2022 03:00

Thanks to the maintainers for a GREAT gem and for your consideration on this PR. 